### PR TITLE
Continuation indent set to 4 from the default 8

### DIFF
--- a/documentation/java/intellij-formatter-synoa.xml
+++ b/documentation/java/intellij-formatter-synoa.xml
@@ -27,6 +27,7 @@
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
     <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
     <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
       <option name="SMART_TABS" value="true" />
     </indentOptions>
   </codeStyleSettings>


### PR DESCRIPTION
 ![Continuation indent 8 (default)](https://user-images.githubusercontent.com/1585112/28311154-04e44460-6baf-11e7-8d53-9c52ed1af3fb.png)
vs
![Continuation indent 4](https://user-images.githubusercontent.com/1585112/28311172-0faf5524-6baf-11e7-91df-a3307964aef7.png)
